### PR TITLE
MaxOSX install for Homebrew

### DIFF
--- a/homebrew/srmio.rb
+++ b/homebrew/srmio.rb
@@ -1,0 +1,18 @@
+require 'formula'
+
+class Srmio < Formula
+  homepage 'http://www.zuto.de/project/srmio/'
+  url 'http://www.zuto.de/project/files/srmio/srmio-0.1.0.tar.gz'
+  sha1 '681fdf78ea0eae889fa93c929c5806da78fcca15'
+
+  def install
+
+    system "./configure", "--disable-debug", "--disable-dependency-tracking",
+                          "--prefix=#{prefix}"
+    system "make install"
+  end
+
+  def test
+    system "srmcmd --help"
+  end
+end


### PR DESCRIPTION
Easy MacOSX install for srmio binaries and libraries using the Homebrew pack system
