### PR TITLE
srmio.h: Include <time.h> unconditionally

### DIFF
--- a/srmio.h
+++ b/srmio.h
@@ -11,6 +11,7 @@
 #define _SRMIO_H
 
 #include <stdio.h>
+#include <time.h>
 #include "srmio_config.h"
 
 #ifdef __cplusplus


### PR DESCRIPTION
The logic to detect <time.h> vs <sys/time.h> no longer works (maybe due to an autoconf change).

Not sure if this is the right fix, but I couldn't tell how `genconfheader.sh` is supposed to work.